### PR TITLE
simple-bitmap-font: don't add extra spaces to the output

### DIFF
--- a/simple-bitmap-font/index.js
+++ b/simple-bitmap-font/index.js
@@ -887,7 +887,7 @@ BitmapFont.prototype.getBitmapStringFromString_horizontal = function(str, scroll
     function pullRow(n){
         return letters_rows.map(function(lr){
             return lr[n];
-        }).join(" ");
+        }).join("");
     }
 
     var str = "";

--- a/simple-bitmap-font/package.json
+++ b/simple-bitmap-font/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-bitmap-font",
-  "version": "0.0.122",
+  "version": "0.0.124",
   "description": "small 8x8 bitmap font for 2d/3d graphics and terminal",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
A join with an extra space for the row adds unnecessary spaces to every character invalidating the use of 8x8 i.e. making it 8x9.